### PR TITLE
Fix client connection errors on node 0.4.11

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -139,7 +139,7 @@ function Client(options) {
   function newConnection() {
     var c;
     if (self.secure) {
-      c = tls.createConnection(self.connectOptions);
+      c = tls.connect(self.connectOptions.port, self.connectOptions.host);
     } else {
       c = net.createConnection(self.connectOptions.port, self.connectOptions.host);
     }


### PR DESCRIPTION
I tried this on Node 0.4.11 and got errors for methods that didn't exist, or invalid arguments.

This fixes it.
