### PR TITLE
The month is off in log messages because of UTC month numbers

### DIFF
--- a/lib/log_stub.js
+++ b/lib/log_stub.js
@@ -35,7 +35,7 @@ function format(level, name, args) {
   var fmtStr = args.shift();
   var fmtArgs = [
     d.getUTCFullYear(),
-    pad(d.getUTCMonth()),
+    pad(d.getUTCMonth() + 1),
     pad(d.getUTCDate()),
     pad(d.getUTCHours()),
     pad(d.getUTCMinutes()),


### PR DESCRIPTION
Changed log_stub format to increment the UTC month number because UTC is 0 - 11 not 1 - 12 month numbers
