### PR TITLE
Fix client 'connect' event being send when using tls.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -627,7 +627,22 @@ Client.prototype.connect = function connect(callback) {
   var self = this;
   var timer = false;
 
-  c = proto.connect(opts.port, opts.host);
+  c = proto.connect(opts.port, opts.host, function () {
+    if (timer)
+      clearTimeout(timer);
+
+    assert.ok(c.ldap);
+
+    c.ldap.id += c.fd ? (':' + c.fd) : '';
+
+    if (log.trace())
+      log.trace('%s connect event', c.ldap.id);
+
+    self.connection = c;
+    self.emit('connect', c);
+
+    return (typeof (callback) === 'function' ? callback(null, c) : false);
+  });
 
   if (this.connectTimeout) {
     timer = setTimeout(function () {
@@ -658,22 +673,6 @@ Client.prototype.connect = function connect(callback) {
     })
   };
 
-  c.on('connect', function () {
-    if (timer)
-      clearTimeout(timer);
-
-    assert.ok(c.ldap);
-
-    c.ldap.id += c.fd ? (':' + c.fd) : '';
-
-    if (log.trace())
-      log.trace('%s connect event', c.ldap.id);
-
-    self.connection = c;
-    self.emit('connect', c);
-
-    return (typeof (callback) === 'function' ? callback(null, c) : false);
-  });
 
   c.on('end', function () {
     if (log.trace())


### PR DESCRIPTION
With `tls.connect()` the socket connect event is 'secureConnect' instead
of 'connect'.
