### PR TITLE
Setting maxConnections value to 1 should not create a ClientPool

### DIFF
--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -54,7 +54,7 @@ module.exports = {
     if (typeof (options.log) !== 'object')
       throw new TypeError('options.log must be an object');
 
-    if (options.maxConnections >= 1)
+    if (options.maxConnections > 1)
       return new ClientPool(options);
 
     return new Client(options);


### PR DESCRIPTION
According to http://ldapjs.org/client.html

> As LDAP is a stateful protocol (as opposed to HTTP), having connections torn down from underneath you is difficult to deal with. That said, the "raw" client, which is what you get when maxConnections is either unset or <= 1, does not do anything for you here; you can handle that however you want.
