### PR TITLE
Use error log level to log errors

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -303,7 +303,8 @@ function Server(options) {
       log.trace('%s shutdown', c.ldap.id);
     });
     c.addListener('error', function (err) {
-      log.error('%s unexpected connection error', c.ldap.id, err);
+      log.warn('%s unexpected connection error', c.ldap.id, err);
+      self.emit('clientError', err);
       c.destroy();
     });
     c.addListener('close', function (had_err) {
@@ -377,7 +378,8 @@ function Server(options) {
         }
 
         if (err) {
-          log.error('%s sending error: %s', req.logId, err.stack || err);
+          log.trace('%s sending error: %s', req.logId, err.stack || err);
+          self.emit('clientError', err);
           sendError(err);
           return after();
         }


### PR DESCRIPTION
This way we'll have some information at the server logs when we get disconnected from the backend of choice, instead of having the server silently failing.
