### PR TITLE
DTrace provider updated to use the libusdt version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "asn1": "0.1.11",
     "assert-plus": "0.1.0",
     "buffertools": "1.1.0",
-    "bunyan": "0.10.0",
-    "dtrace-provider": "0.0.9",
+    "bunyan": "0.13.5",
+    "dtrace-provider": "0.2.0",
     "nopt": "1.0.10",
     "pooling": "0.2.2"
   },


### PR DESCRIPTION
Upgraded dtrace-provider to 0.2.0. And Bunyan to 0.13.5.
