### PR TITLE
Unobtrusive objectGUID formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 *.log
 *.ldif
 *.tar.*
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -35,6 +35,59 @@ on your system:
 ## Installation
 
     npm install ldapjs
+    
+## Formatting objectGUID attribute value
+
+    var ldap = require('ldapjs');
+    
+    ldap.Attribute.settings.guid_format = ldap.GUID_FORMAT_B;
+    
+    var client = ldap.createClient({
+      url: 'ldap://127.0.0.1/CN=test,OU=Development,DC=Home'
+    });
+    
+    var opts = {
+      filter: '(objectclass=user)',
+      scope: 'sub',
+      attributes: ['objectGUID']
+    };
+    
+    client.bind('username', 'password', function (err) {
+      client.search('CN=test,OU=Development,DC=Home', opts, function (err, search) {
+        search.on('searchEntry', function (entry) {
+          var user = entry.object;
+          console.log(user.objectGUID);
+        });
+      });
+    });
+
+_Note: for the sake of simplicity all checks and error handling was removed from the sample above._
+
+The console output may be similar to the following (depending on the amount of users in the directory):
+
+    {a7667bb1-4aee-48ce-9d9d-a1193550deba}
+    {8d642ac8-14c6-4f27-ac5-94d39833da88}
+    
+Available formatting modes:
+
+    GUID_FORMAT_N
+        N specifier, 32 digits:
+        00000000000000000000000000000000
+    GUID_FORMAT_D
+        D specifier, 32 digits separated by hypens:
+        00000000-0000-0000-0000-000000000000
+    GUID_FORMAT_B
+        B specifier, 32 digits separated by hyphens, enclosed in braces:
+        {00000000-0000-0000-0000-000000000000}
+    GUID_FORMAT_P
+        P speficier, 32 digits separated by hyphens, enclosed in parentheses:
+        (00000000-0000-0000-0000-000000000000)
+    GUID_FORMAT_X
+        X speficier, four hexadecimal values enclosed in braces,
+        where the fourth value is a subset of eight hexadecimal values that is also enclosed in braces:
+        {0x00000000,0x0000,0x0000,{0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00}}
+
+Guid formatting is unobtrusive by default. You should explicitly define formatting mode in order to enable it. 
 
 ## License
 

--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -6,7 +6,9 @@ var asn1 = require('asn1');
 
 var Protocol = require('./protocol');
 
-
+var settings = {};
+// specifies Guid display format, not defined (and unobstrusive) by default
+settings.guid_format = '';
 
 ///--- API
 
@@ -37,6 +39,19 @@ function Attribute(options) {
       }
     });
 
+    // processing of objectGUID attribute value
+    if (/objectGUID$/.test(self.type)) {
+      // check whether custom display format was defined
+      if (settings && settings.guid_format && settings.guid_format.length > 0) {
+        // ensure objectGUID value is present within buffers
+        var _buffers = self._vals;
+        if (_buffers && _buffers.length > 0 && Buffer.isBuffer(_buffers[0])) {
+          // return formatted value as per settings
+          return formatGuid(settings.guid_format, _buffers[0]);
+        }
+      }
+    }
+
     return _vals;
   });
 
@@ -66,7 +81,7 @@ function Attribute(options) {
 
 }
 module.exports = Attribute;
-
+module.exports.settings = settings;
 
 Attribute.prototype.addValue = function (val) {
   if (Buffer.isBuffer(val)) {
@@ -166,3 +181,11 @@ Attribute.isAttribute = function (attr) {
 Attribute.prototype.toString = function () {
   return JSON.stringify(this.json);
 };
+
+function formatGuid(format, data) {
+  for (var i = 0; i < data.length; i++) {
+    var re = new RegExp('\\{' + i + '\\}', 'g');
+    format = format.replace(re, data[i].toString(16));
+  }
+  return format;
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,24 @@ var filters = require('./filters');
 var messages = require('./messages');
 var url = require('./url');
 
+// Guid formatting
 
+// N specifier, 32 digits: 
+//  00000000000000000000000000000000
+var GUID_FORMAT_N = '{3}{2}{1}{0}{5}{4}{7}{6}{8}{9}{10}{11}{12}{13}{14}{15}';
+// D specifier, 32 digits separated by hypens:
+//  00000000-0000-0000-0000-000000000000
+var GUID_FORMAT_D = '{3}{2}{1}{0}-{5}{4}-{7}{6}-{8}{9}-{10}{11}{12}{13}{14}{15}';
+// B specifier, 32 digits separated by hyphens, enclosed in braces:
+//  {00000000-0000-0000-0000-000000000000}
+var GUID_FORMAT_B = '{{3}{2}{1}{0}-{5}{4}-{7}{6}-{8}{9}-{10}{11}{12}{13}{14}{15}}';
+// P specifier, 32 digits separated by hyphens, enclosed in parentheses:
+//  (00000000-0000-0000-0000-000000000000)
+var GUID_FORMAT_P = '({3}{2}{1}{0}-{5}{4}-{7}{6}-{8}{9}-{10}{11}{12}{13}{14}{15})';
+// X specifier, Four hexadecimal values enclosed in braces, 
+//  where the fourth value is a subset of eight hexadecimal values that is also enclosed in braces:
+//  {0x00000000,0x0000,0x0000,{0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00}}
+var GUID_FORMAT_X = '{0x{3}{2}{1}{0},0x{5}{4},0x{7}{6},{0x{8},0x{9},0x{10},0x{11},0x{12},0x{13},0x{14},0x{15}}}';
 
 /// Hack a few things we need (i.e., "monkey patch" the prototype)
 
@@ -80,7 +97,13 @@ module.exports = {
 
   parseURL: url.parse,
 
-  url: url
+  url: url,
+
+  GUID_FORMAT_N: GUID_FORMAT_N,
+  GUID_FORMAT_D: GUID_FORMAT_D,
+  GUID_FORMAT_B: GUID_FORMAT_B,
+  GUID_FORMAT_P: GUID_FORMAT_P,
+  GUID_FORMAT_X: GUID_FORMAT_X
 };
 
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "Austin King <shout@ozten.com>",
     "Mathieu Lecarme <mathieu@garambrogne.net>>",
     "Trent Mick <trentm@gmail.com>",
-    "Yunong Xiao <yunong@joyent.com>"
+    "Yunong Xiao <yunong@joyent.com>",
+    "Denis Vuyka <denis.vuyka@gmail.com>"
   ],
   "name": "ldapjs",
   "homepage": "http://ldapjs.org",


### PR DESCRIPTION
I have added several formatting/display modes for 'objectGUID' attribute values. Please refer to updated 'readme' for more details.
