### PR TITLE
Allow changing TLS connection options in client

### DIFF
--- a/docs/client.md
+++ b/docs/client.md
@@ -31,6 +31,7 @@ client is:
 ||timeout||How long the client should let operations live for before timing out. Default is Infinity.||
 ||connectTimeout||How long the client should wait before timing out on TCP connections. Default is up to the OS.||
 ||maxConnections||Whether or not to enable connection pooling, and if so, how many to maintain.||
+||tlsOptions||Additional [options](http://nodejs.org/api/tls.html#tls_tls_connect_port_host_options_callback) passed to the TLS connection layer when connecting via `ldaps://`||
 
 If using connection pooling, you can additionally pass in:
 

--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -231,6 +231,7 @@ function Client(options) {
   this.log = options.log.child({clazz: 'Client'}, true);
   this.port = _url ? _url.port : false;
   this.secure = _url ? _url.secure : false;
+  this.tlsOptions = options.tlsOptions;
   this.socketPath = options.socketPath || false;
   this.timeout = parseInt((options.timeout || 0), 10);
   this.url = _url;
@@ -721,7 +722,7 @@ Client.prototype._connect = function _connect() {
     self.emit('connect', socket);
   }
 
-  socket = proto.connect((this.port || this.socketPath), this.host);
+  socket = proto.connect((this.port || this.socketPath), this.host, this.secure ? this.tlsOptions : null);
 
   socket.once('connect', onConnect);
   socket.once('secureConnect', onConnect);

--- a/lib/client/pool.js
+++ b/lib/client/pool.js
@@ -115,7 +115,8 @@ function ClientPool(options) {
     log: options.log,
     socketPath: options.socketPath,
     timeout: (options.timeout || 0),
-    url: options.url
+    url: options.url,
+    tlsOptions: options.tlsOptions
   };
   this.pool = createPool(options);
 }


### PR DESCRIPTION
node v0.10 TLS validates server certificates by default, so allow for setting custom connection options (e. g. `ca` or `rejectUnauthorized`).

Quoting node's [changelog](https://github.com/joyent/node/blob/master/ChangeLog):

> 2012.09.17, Version 0.9.2 (Unstable)
> ...
> - tls, https: validate server certificate by default (Ben Noordhuis)
