### PR TITLE
Send CA Certificate path in options

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -4,6 +4,7 @@ var EventEmitter = require('events').EventEmitter;
 var net = require('net');
 var tls = require('tls');
 var util = require('util');
+var fs = require('fs');
 
 var assert = require('assert-plus');
 
@@ -234,6 +235,7 @@ function Client(options) {
   this.socketPath = options.socketPath || false;
   this.timeout = parseInt((options.timeout || 0), 10);
   this.url = _url;
+  this.ca = options.ca ? options.ca : false;
 
   this.socket = this._connect();
 }
@@ -721,7 +723,17 @@ Client.prototype._connect = function _connect() {
     self.emit('connect', socket);
   }
 
-  socket = proto.connect((this.port || this.socketPath), this.host);
+  var secureOptions;
+  if(this.secure && this.ca){
+      var ca;
+      try {
+          ca = fs.readFileSync(this.ca);
+      }catch (e) {
+          ca = false;
+      }
+      secureOptions = ca ?  { ca : ca } : null;
+  }
+  socket = proto.connect((this.port || this.socketPath), this.host , secureOptions);
 
   socket.once('connect', onConnect);
   socket.once('secureConnect', onConnect);


### PR DESCRIPTION
When connecting a client to an ldaps connection, TLS is not able to locate installed CAs. As I understand it, TLS needs the certificate to be passed in the tls#connect options. http://nodejs.org/api/tls.html#tls_tls_connect_options_callback
