### PR TITLE
allow binding ldap server on an ephemeral port

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -651,7 +651,7 @@ Server.prototype.after = function () {
 
 // All these just reexpose the requisite net.Server APIs
 Server.prototype.listen = function (port, host, callback) {
-  if (!port)
+  if (typeof port !== 'number')
     throw new TypeError('port (number) required');
 
   if (typeof (host) === 'function') {
@@ -662,8 +662,8 @@ Server.prototype.listen = function (port, host, callback) {
 
   function _callback() {
     if (typeof (port) === 'number') {
-      self.host = host;
-      self.port = port;
+      self.host = self.address().address;
+      self.port = self.address().port;
     } else {
       self.host = port;
       self.port = self.server.fd;


### PR DESCRIPTION
if the client specifies a port of zero, bind to an ephemeral port.  This allows for the construction of robust local tests that use a local ldap server.
