### PR TITLE
Fix fork banner and chpassword error handling

### DIFF
--- a/guide.html
+++ b/guide.html
@@ -84,7 +84,7 @@ h1,h2,h3,h4,h5,h6 {
   </span>
 
   <a id="githubfork" href="http://github.com/mcavage/node-ldapjs">
-    <img src="https://a248.e.akamai.net/assets.github.com/img/abad93f42020b733148435e2cd92ce15c542d320/687474703a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f677265656e5f3030373230302e706e67"
+    <img src="https://s3.amazonaws.com/github/ribbons/forkme_right_green_007200.png"
          alt="Fork me on GitHub">
   </a>
 </div>
@@ -683,7 +683,7 @@ Go ahead and add the following code into your source file:</p>
 
   passwd.on('exit', function(code) {
     if (code !== 0)
-      return next(new ldap.OperationsError(code));
+      return next(new ldap.OperationsError(code.toString()));
 
     res.end();
     return next();


### PR DESCRIPTION
- Banner img tag referencing outdated CDN artifact now using official link
- Missing chpassword would cause EPIPE, now passing in String not Number
