### PR TITLE
Fixes #139 - Bump required tap version to 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "pooling": "0.4.4"
   },
   "devDependencies": {
-    "tap": "0.4.0",
+    "tap": "0.4.1",
     "node-uuid": "1.4.0"
   },
   "scripts": {


### PR DESCRIPTION
When using node 0.10, test initiation will fail due to differences in
the array.map function.  This discrepancy is corrected in tap v0.4.1.
See: https://github.com/isaacs/node-tap/issues/70
