### PR TITLE
add '-i, --insecure' option and LDAPJS_TLS_INSECURE=1 envvar support to all ldapjs-* CLIs

### DIFF
--- a/bin/ldapjs-add
+++ b/bin/ldapjs-add
@@ -25,6 +25,7 @@ var opts = {
   'debug': Number,
   'binddn': ldap.DN,
   'file': String,
+  'insecure': Boolean,
   'password': String,
   'url': url
 };
@@ -33,6 +34,7 @@ var shortOpts = {
   'd': ['--debug'],
   'D': ['--binddn'],
   'f': ['--file'],
+  'i': ['--insecure'],
   'w': ['--password'],
   'u': ['--url']
 };
@@ -90,6 +92,15 @@ try {
   usage(1, e.toString());
 }
 
+if (parsed.insecure === undefined &&
+    process.env.LDAPJS_TLS_INSECURE !== undefined) {
+  if (process.env.LDAPJS_TLS_INSECURE === '0') {
+    parsed.insecure = false;
+  } else {
+    parsed.insecure = true;
+  }
+}
+
 if (parsed.help)
   usage(0);
 if (!parsed.file) {
@@ -127,7 +138,10 @@ var log = new Logger({
 
 var client = ldap.createClient({
   url: parsed.url,
-  log: log
+  log: log,
+  tlsOptions: {
+    rejectUnauthorized: !parsed.insecure
+  }
 });
 
 client.on('error', function(err) {

--- a/bin/ldapjs-compare
+++ b/bin/ldapjs-compare
@@ -26,6 +26,7 @@ var opts = {
   'debug': Number,
   'binddn': ldap.DN,
   'file': String,
+  'insecure': Boolean,
   'password': String,
   'url': url,
   'value': String,
@@ -36,6 +37,7 @@ var shortOpts = {
   'd': ['--debug'],
   'D': ['--binddn'],
   'f': ['--file'],
+  'i': ['--insecure'],
   'w': ['--password'],
   'u': ['--url'],
   'v': ['--value']
@@ -89,6 +91,15 @@ try {
   usage(1, e.toString());
 }
 
+if (parsed.insecure === undefined &&
+    process.env.LDAPJS_TLS_INSECURE !== undefined) {
+  if (process.env.LDAPJS_TLS_INSECURE === '0') {
+    parsed.insecure = false;
+  } else {
+    parsed.insecure = true;
+  }
+}
+
 if (parsed.help)
   usage(0);
 
@@ -123,7 +134,10 @@ var log = new Logger({
 
 var client = ldap.createClient({
   url: parsed.url,
-  log: log
+  log: log,
+  tlsOptions: {
+    rejectUnauthorized: !parsed.insecure
+  }
 });
 
 client.on('error', function(err) {

--- a/bin/ldapjs-delete
+++ b/bin/ldapjs-delete
@@ -24,6 +24,7 @@ nopt.typeDefs.DN = {
 var opts = {
   'debug': Number,
   'binddn': ldap.DN,
+  'insecure': Boolean,
   'password': String,
   'url': url
 };
@@ -31,6 +32,7 @@ var opts = {
 var shortOpts = {
   'd': ['--debug'],
   'D': ['--binddn'],
+  'i': ['--insecure'],
   'w': ['--password'],
   'u': ['--url']
 };
@@ -83,6 +85,15 @@ try {
   usage(1, e.toString());
 }
 
+if (parsed.insecure === undefined &&
+    process.env.LDAPJS_TLS_INSECURE !== undefined) {
+  if (process.env.LDAPJS_TLS_INSECURE === '0') {
+    parsed.insecure = false;
+  } else {
+    parsed.insecure = true;
+  }
+}
+
 if (parsed.help)
   usage(0);
 if (parsed.argv.remain.length < 1)
@@ -113,7 +124,10 @@ var log = new Logger({
 
 var client = ldap.createClient({
   url: parsed.url,
-  log: log
+  log: log,
+  tlsOptions: {
+    rejectUnauthorized: !parsed.insecure
+  }
 });
 
 client.on('error', function(err) {

--- a/bin/ldapjs-modify
+++ b/bin/ldapjs-modify
@@ -26,6 +26,7 @@ var opts = {
   'debug': Number,
   'binddn': ldap.DN,
   'file': String,
+  'insecure': Boolean,
   'password': String,
   'type': String,
   'url': url,
@@ -37,6 +38,7 @@ var shortOpts = {
   'd': ['--debug'],
   'D': ['--binddn'],
   'f': ['--file'],
+  'i': ['--insecure'],
   'w': ['--password'],
   't': ['--type'],
   'u': ['--url'],
@@ -91,6 +93,15 @@ try {
   usage(1, e.toString());
 }
 
+if (parsed.insecure === undefined &&
+    process.env.LDAPJS_TLS_INSECURE !== undefined) {
+  if (process.env.LDAPJS_TLS_INSECURE === '0') {
+    parsed.insecure = false;
+  } else {
+    parsed.insecure = true;
+  }
+}
+
 if (parsed.help)
   usage(0);
 
@@ -127,7 +138,10 @@ var log = new Logger({
 
 var client = ldap.createClient({
   url: parsed.url,
-  log: log
+  log: log,
+  tlsOptions: {
+    rejectUnauthorized: !parsed.insecure
+  }
 });
 
 client.on('error', function(err) {

--- a/bin/ldapjs-search
+++ b/bin/ldapjs-search
@@ -33,6 +33,7 @@ var opts = {
   'base': ldap.DN,
   'binddn': ldap.DN,
   'control': Array,
+  'insecure': Boolean,
   'password': String,
   'persistent': Boolean,
   'paged': Number,
@@ -46,6 +47,7 @@ var shortOpts = {
   'd': ['--debug'],
   'b': ['--base'],
   'D': ['--binddn'],
+  'i': ['--insecure'],
   'w': ['--password'],
   'p': ['--persistent'],
   'g': ['--paged'],
@@ -101,6 +103,15 @@ try {
   usage(1, e.toString());
 }
 
+if (parsed.insecure === undefined &&
+    process.env.LDAPJS_TLS_INSECURE !== undefined) {
+  if (process.env.LDAPJS_TLS_INSECURE === '0') {
+    parsed.insecure = false;
+  } else {
+    parsed.insecure = true;
+  }
+}
+
 if (parsed.help)
   usage(0);
 if (parsed.argv.remain.length < 1)
@@ -139,7 +150,10 @@ var log = new Logger({
 var client = ldap.createClient({
   url: parsed.url,
   log: log,
-  timeout: parsed.timeout || false
+  timeout: parsed.timeout || false,
+  tlsOptions: {
+    rejectUnauthorized: !parsed.insecure
+  }
 });
 
 client.on('error', function(err) {


### PR DESCRIPTION
This is required when using node 0.10 and talking to a ldaps://
LDAP server with a self-signed cert. Otherwise you get:

```
$ ./ldapjs-search --url ldaps://ldap.example.com:636 ...
DEPTH_ZERO_SELF_SIGNED_CERT
```
