### PR TITLE
Accept buffers for cert/key in createServer

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -259,7 +259,7 @@ function Server(options) {
     if (options.certificate || options.key) {
       if (!(options.certificate && options.key) ||
           (typeof (options.certificate) !== 'string' &&
-          !Buffer.isBuffer(options.key)) ||
+          !Buffer.isBuffer(options.certificate)) ||
           (typeof (options.key) !== 'string' &&
           !Buffer.isBuffer(options.key))) {
         throw new TypeError('options.certificate and options.key ' +


### PR DESCRIPTION
As ldap.createServer() actually makes use of [tls.createServer()](http://nodejs.org/api/tls.html#tls_tls_createserver_options_secureconnectionlistener) when key and certifcate are provided, we can pass buffer objects, too.
