### PR TITLE
server.unbind fails to trigger

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -797,13 +797,13 @@ Server.prototype._getHandlerChain = function _getHandlerChain(req, res) {
     route = routes['unbind'];
     return {
       backend: route ? route.backend : self,
-      handlers: function getUnbindChain() {
+      handlers: (function getUnbindChain() {
         if (route && route[op])
           return route[op];
 
         self.log.debug('%s unbind request %j', req.logId, req.json);
         return [defaultNoOpHandler];
-      }
+      }())
     };
   } else if (req.protocolOp === Protocol.LDAP_REQ_ABANDON) {
     return {


### PR DESCRIPTION
A short reproducer:

```
#!/usr/bin/env node
var server = require("./lib/index").createServer();
server.bind("o=foo", function(req, res, next) {
    console.log("bind");
    res.end();
    return next();
});
server.search("o=foo", function(req, res, next) {
    console.log("search");
    res.end();
    return next();
});
server.unbind(function(req, res, next) {
    console.log("unbind");
    return next();
});
server.listen(1389);
```

When you run this server and run a search with a bind, like so:

```
ldapsearch -x -h localhost:1389 -D o=foo -w x -b o=foo
```

it should've output `bind`, `search` and `unbind`, but it only outputs `bind` and `search`.

I've tracked it down deep into the depths of the server code where the code determining what to do with the unbind request returns "a function that returns a handler" instead of returning the handler. See my commit. I'm fairly new with javascript and not sure if this is good practice or not.
