### PR TITLE
fix #222: add support for AD UPN bind DNs

### DIFF
--- a/bin/ldapjs-add
+++ b/bin/ldapjs-add
@@ -23,6 +23,14 @@ dashdash.addOptionType({
   }
 });
 
+dashdash.addOptionType({
+  name: 'ldap.BIND_DN',
+  takesArg: true,
+  helpArg: 'LDAP_BIND_DN',
+  parseArg: function (option, optstr, arg) {
+    return ldap.parseDN(arg, true);
+  }
+});
 
 var opts = [
   {
@@ -53,7 +61,7 @@ var opts = [
   },
   {
     names: ['binddn', 'D'],
-    type: 'ldap.DN',
+    type: 'ldap.BIND_DN',
     help: 'Bind DN',
     default: ''
   },

--- a/bin/ldapjs-compare
+++ b/bin/ldapjs-compare
@@ -22,6 +22,15 @@ dashdash.addOptionType({
   }
 });
 
+dashdash.addOptionType({
+  name: 'ldap.BIND_DN',
+  takesArg: true,
+  helpArg: 'LDAP_BIND_DN',
+  parseArg: function (option, optstr, arg) {
+    return ldap.parseDN(arg, true);
+  }
+});
+
 
 var opts = [
   {
@@ -58,7 +67,7 @@ var opts = [
   },
   {
     names: ['binddn', 'D'],
-    type: 'ldap.DN',
+    type: 'ldap.BIND_DN',
     help: 'Bind DN',
     default: ''
   },

--- a/bin/ldapjs-delete
+++ b/bin/ldapjs-delete
@@ -22,6 +22,15 @@ dashdash.addOptionType({
   }
 });
 
+dashdash.addOptionType({
+  name: 'ldap.BIND_DN',
+  takesArg: true,
+  helpArg: 'LDAP_BIND_DN',
+  parseArg: function (option, optstr, arg) {
+    return ldap.parseDN(arg, true);
+  }
+});
+
 
 var opts = [
   { group: 'General Options' },
@@ -46,7 +55,7 @@ var opts = [
   },
   {
     names: ['binddn', 'D'],
-    type: 'ldap.DN',
+    type: 'ldap.BIND_DN',
     help: 'Bind DN',
     default: ''
   },

--- a/bin/ldapjs-modify
+++ b/bin/ldapjs-modify
@@ -22,6 +22,15 @@ dashdash.addOptionType({
   }
 });
 
+dashdash.addOptionType({
+  name: 'ldap.BIND_DN',
+  takesArg: true,
+  helpArg: 'LDAP_BIND_DN',
+  parseArg: function (option, optstr, arg) {
+    return ldap.parseDN(arg, true);
+  }
+});
+
 
 var opts = [
   {
@@ -64,7 +73,7 @@ var opts = [
   },
   {
     names: ['binddn', 'D'],
-    type: 'ldap.DN',
+    type: 'ldap.BIND_DN',
     help: 'Bind DN',
     default: ''
   },

--- a/bin/ldapjs-search
+++ b/bin/ldapjs-search
@@ -22,6 +22,15 @@ dashdash.addOptionType({
 });
 
 dashdash.addOptionType({
+  name: 'ldap.BIND_DN',
+  takesArg: true,
+  helpArg: 'LDAP_BIND_DN',
+  parseArg: function (option, optstr, arg) {
+    return ldap.parseDN(arg, true);
+  }
+});
+
+dashdash.addOptionType({
   name: 'ldap.Filter',
   takesArg: true,
   helpArg: 'LDAP_FILTER',
@@ -104,7 +113,7 @@ var opts = [
   },
   {
     names: ['binddn', 'D'],
-    type: 'ldap.DN',
+    type: 'ldap.BIND_DN',
     help: 'Bind DN',
     default: ''
   },

--- a/lib/dn.js
+++ b/lib/dn.js
@@ -46,10 +46,51 @@ RDN.prototype.toString = function () {
   return str;
 };
 
+function UPN(accountName, domainOrNetbiosName, hasNetbiosName) {
+  this.accountName = accountName;
+  if (!hasNetbiosName) {
+    this.domainName = domainOrNetbiosName;
+  } else {
+    this.netbiosName = domainOrNetbiosName;
+  }
+}
+
+UPN.parse = function (str) {
+  var upnRE = /^([a-zA-Z0-9][\w\.-]*[a-zA-Z0-9])@([a-zA-Z0-9][\w\.-]*[a-zA-Z0-9])$/,
+    upnLegacyRE = /^([a-zA-Z0-9][\w\.-]*[a-zA-Z0-9])[/\/]([a-zA-Z0-9][\w\.-]*[a-zA-Z0-9])$/,
+    match;
+  if ((match = upnRE.exec(str))) {
+    var account = match[1],
+      domain = match[2];
+    return new UPN(account, domain);
+  } else if ((match = upnLegacyRE.exec(str))) {
+    var legacyNetbios = match[1],
+      legacyAccount = match[2];
+    return new UPN(legacyAccount, legacyNetbios, true);
+  } else {
+    return undefined;
+  }
+};
+
+UPN.prototype.toString = function() {
+  if (!this.netbiosName) {
+    return this.accountName + '@' + this.domainName;
+  } else {
+    return this.netbiosName + '/' + this.accountName;
+  }
+};
+
+
 // Thank you OpenJDK!
-function parse(name) {
+function parse(name, allowActiveDirectoryUPN) {
   if (typeof (name) !== 'string')
     throw new TypeError('name (string) required');
+
+  if (allowActiveDirectoryUPN){
+    var upn = UPN.parse(name);
+    if (upn)
+      return new DN([upn]).spaced(false);
+  }
 
   var cur = 0;
   var len = name.length;

--- a/test/dn.test.js
+++ b/test/dn.test.js
@@ -79,6 +79,36 @@ test('parse quoted', function (t) {
 });
 
 
+test('parse AD UPN (user@domain)', function (t){
+  var DN_STR = 'mcavage@joyent';
+  var name = dn.parse(DN_STR, true);
+  t.ok(name);
+  t.ok(name.rdns);
+  t.ok(Array.isArray(name.rdns));
+  t.equal(1, name.rdns.length);
+  name.rdns.forEach(function (rdn) {
+    t.equal('object', typeof (rdn));
+  });
+  t.equal(name.toString(), DN_STR);
+  t.end();
+});
+
+
+test('parse AD UPN (netbios/user)', function (t){
+  var DN_STR = 'joyent/mcavage';
+  var name = dn.parse(DN_STR, true);
+  t.ok(name);
+  t.ok(name.rdns);
+  t.ok(Array.isArray(name.rdns));
+  t.equal(1, name.rdns.length);
+  name.rdns.forEach(function (rdn) {
+    t.equal('object', typeof (rdn));
+  });
+  t.equal(name.toString(), DN_STR);
+  t.end();
+});
+
+
 test('equals', function (t) {
   var dn1 = dn.parse('cn=foo, dc=bar');
   t.ok(dn1.equals('cn=foo, dc=bar'));


### PR DESCRIPTION
This fixes #222 and adds basic support for Active Directory UPN bind DNs (both modern and legacy).

Examples of AD UPN bind DNs that this will support for those who are unfamiliar:
- modern - `joeuser@AD`
- legacy - `AD/joeuser`

The command line utilities support AD UPN bind DNs.

When using the API you will need to _explicitly_ enable support for AD UPN bind DNs: `parseDN(name, allowActiveDirectoryUPN)`
