### PR TITLE
fix #225: fix EPIPE errors when piped through head command

### DIFF
--- a/bin/ldapjs-search
+++ b/bin/ldapjs-search
@@ -155,6 +155,14 @@ function perror(err) {
 
 var parsed;
 
+process.stdout.on('error', function(err) {
+  if (err.code === 'EPIPE') {
+    process.exit(0);
+  } else {
+    throw err;
+  }
+});
+
 try {
   parsed = parser.parse(process.argv);
 } catch (e) {


### PR DESCRIPTION
This fixes issue #225 where piping output through something like `head` could cause `EPIPE` errors.

It simply catches the EPIPE error and exits.
Any other `stdout` errors will be rethrown.
