### PR TITLE
Quick patch to fix #245

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -105,7 +105,7 @@ function setupSocket(socket, opts) {
 
   // Since tls.socket doesn't emit 'close' events, we must register to receive
   // them on net.socket instead
-  var closeSocket = (opts.secure ? socket.socket : socket);
+  var closeSocket = socket;
   // On close we have to walk the outstanding messages and go invoke their
   // callback with an error.
   closeSocket.on('close', function onClose(had_err) {


### PR DESCRIPTION
Seems like in newer versions of nodejs and iojs, tls.socket does emit socket close events. We don't need to listen for the net.socket events, so we can just assign closeSocket to socket.