### PR TITLE
Expose the Client as a module-level export

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
 var Logger = require('bunyan');
 
 var client = require('./client');
+var Client = require('./client/client');
 var Attribute = require('./attribute');
 var Change = require('./change');
 var Protocol = require('./protocol');
@@ -21,6 +22,7 @@ var url = require('./url');
 ///--- API
 
 module.exports = {
+  Client: Client,
   createClient: client.createClient,
 
   Server: Server,


### PR DESCRIPTION
This is so one can modify the client's prototype (for reasons such as promisification)