### PR TITLE
permit search base to be an empty string

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -750,7 +750,7 @@ Client.prototype.search = function search(base,
                                           controls,
                                           callback,
                                           _bypass) {
-  assert.ok(base, 'base');
+  assert.equal(typeof base, 'string', 'base');
   if (Array.isArray(options) || (options instanceof Control)) {
     controls = options;
     options = {};


### PR DESCRIPTION
which is necessary when one desires to discover the 'base' for future operations. Example:

```js
var base = '';
ldap.search(base,
    {
        scope: 'base',
        filter: '(objectclass=*)',
        attributes: [ 'defaultNamingContext' ],
    },
    function (err, res) {
        // ...
    });
```