### PR TITLE
Attribute prototype getters setters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage
 *.tar.*
 *.tgz
 .DS_Store
+.idea

--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -9,6 +9,10 @@ var Protocol = require('./protocol');
 
 ///--- API
 
+/**
+ * @constructor
+ * @param [options={}]
+ */
 function Attribute(options) {
   if (options) {
     if (typeof (options) !== 'object')
@@ -19,52 +23,62 @@ function Attribute(options) {
     options = {};
   }
 
-  var self = this;
-
   this.type = options.type || '';
   this._vals = [];
 
-  this.__defineGetter__('vals', function () {
-    var _vals = [];
-
-    self._vals.forEach(function (v) {
-      /* JSSTYLED */
-      if (/;binary$/.test(self.type)) {
-        _vals.push(v.toString('base64'));
-      } else {
-        _vals.push(v.toString('utf8'));
-      }
-    });
-
-    return _vals;
-  });
-
-  this.__defineSetter__('vals', function (vals) {
-    if (Array.isArray(vals)) {
-      vals.forEach(function (v) {
-        self.addValue(v);
-      });
-    } else {
-      self.addValue(vals);
-    }
-  });
-
-  this.__defineGetter__('buffers', function () {
-    return self._vals;
-  });
-
-  this.__defineGetter__('json', function () {
-    return {
-      type: self.type,
-      vals: self.vals
-    };
-  });
-
   if (options.vals !== undefined && options.vals !== null)
     this.vals = options.vals;
-
 }
+
 module.exports = Attribute;
+
+Object.defineProperties(Attribute.prototype, {
+
+  buffers: {
+    get: function () {
+      var self = this;
+      return self._vals;
+    },
+    configurable: false
+  },
+
+  json: {
+    get: function() {
+      var self = this;
+      return {
+        type: self.type,
+        vals: self.vals
+      };
+    },
+    configurable: false
+  },
+
+  vals: {
+    get: function() {
+      var self = this;
+      var type = self.type;
+      var _vals = self._vals;
+      return _vals.map(function(v) {
+        /* JSSTYLED */
+        var encoding = /;binary$/.test(self.type) ? 'base64' : 'utf8';
+        return v.toString(encoding);
+      });
+    },
+    set: function(vals) {
+      var self = this;
+      this._vals = [];
+      if (Array.isArray(vals)) {
+        vals.forEach(function(v) {
+          self.addValue(v);
+        });
+      } else {
+        self.addValue(vals);
+      }
+    },
+    configurable: false
+  }
+
+});
 
 Attribute.prototype.addValue = function (val) {
   if (Buffer.isBuffer(val)) {

--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -59,9 +59,7 @@ Object.defineProperties(Attribute.prototype, {
       var type = self.type;
       var _vals = self._vals;
       return _vals.map(function(v) {
-        /* JSSTYLED */
-        var encoding = /;binary$/.test(self.type) ? 'base64' : 'utf8';
-        return v.toString(encoding);
+        return v.toString(_getEncodingFromType(type));
       });
     },
     set: function(vals) {
@@ -81,15 +79,7 @@ Object.defineProperties(Attribute.prototype, {
 });
 
 Attribute.prototype.addValue = function (val) {
-  if (Buffer.isBuffer(val)) {
-    this._vals.push(val);
-  } else {
-    var encoding = 'utf8';
-    /* JSSTYLED */
-    if (/;binary$/.test(this.type))
-      encoding = 'base64';
-    this._vals.push(new Buffer(val + '', encoding));
-  }
+  this._vals.push(_valueToBuffer(val, this.type));
 };
 
 
@@ -183,3 +173,27 @@ Attribute.isAttribute = function (attr) {
 Attribute.prototype.toString = function () {
   return JSON.stringify(this.json);
 };
+
+/**
+ * Gets the encoding to use based on the type of the attribute
+ * @param {string} type
+ * @returns {string}
+ * @private
+ */
+function _getEncodingFromType(type) {
+  /* JSSTYLED */
+  return /;binary$/.test(type) ? 'base64' : 'utf8';
+}
+
+/**
+ * Converts a value to a buffer based on the given type
+ * @param {*} val
+ * @param {string} type
+ * @returns {Buffer}
+ * @private
+ */
+function _valueToBuffer(val, type) {
+  return Buffer.isBuffer(val) ?
+    val :
+    new Buffer(val + '', _getEncodingFromType(type));
+}


### PR DESCRIPTION
* Move `buffers`, `json`, `vals` getters/setters to prototype
* Update attributes tests to cover 100% of code
* Ignore JetBrains IDE folder