### PR TITLE
Adding the possibility to set manually the flag 'secure'

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -310,7 +310,7 @@ function Client(options) {
     _url = url.parse(options.url);
   this.host = _url ? _url.hostname : undefined;
   this.port = _url ? _url.port : false;
-  this.secure = _url ? _url.secure : false;
+  this.secure = options.secure ? option.secure : _url ? _url.secure : false;
   this.url = _url;
   this.tlsOptions = options.tlsOptions;
   this.socketPath = options.socketPath || false;


### PR DESCRIPTION
Hi, I've been using this module for a while and it turned that I have a problem where the company I work for, they use a secure connection to access to the LDAP information but they are not using the protocol: `ldaps://` they are using the protocol: `ldap://`. So I decide to modify the package, passing manually the `secure` value where I create the client:

```javascript
var client = ldap.createClient({
    url:'ldap://www.company.org',
    secure:true
});
```

Just for the record I tried with different url combinations and just modifying the module is how I got it working