### PR TITLE
Remove useless console.log

### DIFF
--- a/lib/change.js
+++ b/lib/change.js
@@ -77,7 +77,6 @@ Object.defineProperties(Change.prototype, {
       }
 
       var k = keys[0];
-      console.log(keys);
       var _attr = new Attribute({type: k});
       if (Array.isArray(val[k])) {
         val[k].forEach(function (v) {

--- a/lib/controls/control.js
+++ b/lib/controls/control.js
@@ -21,7 +21,6 @@ function Control(options) {
   assert.optionalString(options.type);
   assert.optionalBool(options.criticality);
   if (options.value) {
-  console.log(assert.buffer.toString());
     assert.buffer(options.value);
   }
 


### PR DESCRIPTION
Some kind of style fix to remove a redundant console.log
Ths logs are drawn every time something is updated which makes logs dirty.