### PR TITLE
Bump dtrace-provider and bunyan versions to better support Node 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "asn1": "0.2.3",
     "assert-plus": "0.2.0",
-    "bunyan": "1.5.1",
+    "bunyan": "1.8.2",
     "dashdash": "1.10.1",
     "backoff": "2.4.1",
     "ldap-filter": "0.2.2",
@@ -40,7 +40,7 @@
     "verror": "1.6.0"
   },
   "optionalDependencies": {
-    "dtrace-provider": "0.6.0"
+    "dtrace-provider": "0.7.0"
   },
   "devDependencies": {
     "node-uuid": "1.4.3",


### PR DESCRIPTION
These 2 dependencies have compatibility issues with Node 6 due to their specific dependency on older versions of `nodejs/nan`.

Bumping their version will ensure compatibility with Node 6, see:

- https://github.com/chrisa/node-dtrace-provider/commit/ea042a35d184e4b4fea45b9c7cd9d53496674af9
- https://github.com/trentm/node-bunyan/pull/449